### PR TITLE
Evolution de l'API ADEME vers V2

### DIFF
--- a/src/lib/searchDPE.ts
+++ b/src/lib/searchDPE.ts
@@ -24,8 +24,13 @@ async function getDPE({ lon, lat }: Coord) {
     console.log(url)
     const response = await (await fetch(url)).json();
     return {
-        classe_consommation_energie: response.results[0].classe_consommation_energie,
-        geo_adresse: response.results[0].geo_adresse,
-        annee_construction: response.results[0].annee_construction
+        surface: response.results[0]['Surface_habitable_logement'],
+        conso_annuelle_m2: response.results[0]['Conso_5_usages/m²_é_finale'],
+        dpe: response.results[0]['Etiquette_DPE'],
+        ges: response.results[0]['Etiquette_GES'],
+        annee_construction: response.results[0]['Année_construction'],
+        num_addresse: response.results[0]['N°_voie_(BAN)'],
+        nom_rue: response.results[0]['Nom__rue_(BAN)'],
+        commune: response.results[0]['Nom__commune_(BAN)'],
     }
 }

--- a/src/lib/searchDPE.ts
+++ b/src/lib/searchDPE.ts
@@ -1,5 +1,5 @@
 
-const dpeEndpoint = "https://data.ademe.fr/data-fair/api/v1/datasets/dpe-france/lines/?select=classe_consommation_energie%2Cannee_construction%2Cgeo_adresse"
+const dpeEndpoint = "https://data.ademe.fr/data-fair/api/v1/datasets/dpe-v2-logements-existants/lines?select=N%C2%B0DPE%2CEtiquette_GES%2CEtiquette_DPE%2CAnn%C3%A9e_construction%2CNom__commune_(BAN)%2CN%C2%B0_voie_(BAN)%2CNom__rue_(BAN)%2CConso_5_usages%2Fm%C2%B2_%C3%A9_finale%2CSurface_habitable_logement"
 const adressEnpoint = "https://api-adresse.data.gouv.fr/search/";
 
 type Coord = { lon: number, lat: number };


### PR DESCRIPTION
Utilisation de la nouvelle version de l'API de l'ADEME, qui couvre les DPE effectués depuis 2021.

* Modification de l'endpoint
* Modifications de noms de paramètres
* Ajout de nouveaux paramètres, uniquement dispo ds v2